### PR TITLE
Fix deprecated atom.workspaceView

### DIFF
--- a/lib/line-ending-converter.coffee
+++ b/lib/line-ending-converter.coffee
@@ -8,9 +8,9 @@ class LineEndingConverter
   @OLD_MAC_FORMAT: '\r'
 
   constructor: ->
-    atom.workspaceView.command 'line-ending-converter:convert-to-unix-format', => @convertToUnixFormat()
-    atom.workspaceView.command 'line-ending-converter:convert-to-windows-format', => @convertToWindowsFormat()
-    atom.workspaceView.command 'line-ending-converter:convert-to-old-mac-format', => @convertToOldMacFormat()
+    atom.commands.add 'atom-workspace', 'line-ending-converter:convert-to-unix-format', => @convertToUnixFormat()
+    atom.commands.add 'atom-workspace', 'line-ending-converter:convert-to-windows-format', => @convertToWindowsFormat()
+    atom.commands.add 'atom-workspace', 'line-ending-converter:convert-to-old-mac-format', => @convertToOldMacFormat()
 
   convertToUnixFormat: ->
     if editor = atom.workspace.getActiveEditor()


### PR DESCRIPTION
Fix for "atom.workspaceView is no longer available. In most cases you will not need the view. See the Workspace docs for alternatives: https://atom.io/docs/api/latest/Workspace. If you do need the view, please use atom.views.getView(atom.workspace), which returns an HTMLElement."